### PR TITLE
Fix naming in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ static void foobar()
 }
 ```
 
-Feestanding Implementation
+Freestanding Implementation
 --------------------------
 The library also supports experimental freestanding mode, to allow running in an environment
 without exceptions and rtti.


### PR DESCRIPTION
Changed "Feestanding" to "Freestanding"